### PR TITLE
Incompatibility with themes that do not have a background.

### DIFF
--- a/lua/volt/highlights.lua
+++ b/lua/volt/highlights.lua
@@ -22,7 +22,8 @@ if vim.g.base46_cache then
   }
 else
   local normal_bg = api.nvim_get_hl(0, { name = "Normal" }).bg
-  normal_bg = ("%06x"):format(normal_bg)
+  
+  normal_bg = ("%06x"):format((normal_bg == nil and 0 or normal_bg))
 
   local darker_bg = lighten(normal_bg, -3)
   local lighter_bg = lighten(normal_bg, 5)


### PR DESCRIPTION
I tried using minty and it failed because a field was nil. After disabling my theme plugin (parz3val/pywal-complete.nvim) it seemed to work so I'm guessing this is not a general issue with this project but with the pywal16 plugin. But since there might be other themes which also do not have a background color defined I added a null check to the field and set it to 0 in case it is equal to `nil`.

Quite new to lua so I'm sorry if my code doesn't comply with some standards or best practices.