### PR TITLE
feat: set a unique filetype for volt buffers

### DIFF
--- a/lua/volt/draw.lua
+++ b/lua/volt/draw.lua
@@ -11,6 +11,8 @@ return function(buf, section)
     local row = line_i + section.row
     local col = xpad
 
+    vim.bo[buf].filetype = "VoltWindow"
+
     v.clickables[row] = {}
     v.hoverables[row] = {}
 


### PR DESCRIPTION
This sets a unique filetype to volt buffers.

This will allow users/plugins to determine when a volt window is active and react accordingly.