### PR TITLE
fix(highlights): avoid overriding existing highlight definitions

### DIFF
--- a/lua/volt/highlights.lua
+++ b/lua/volt/highlights.lua
@@ -63,5 +63,7 @@ else
 end
 
 for name, val in pairs(highlights) do
-  vim.api.nvim_set_hl(0, name, val)
+  if vim.tbl_isempty(vim.api.nvim_get_hl(0, { name = name })) then
+    vim.api.nvim_set_hl(0, name, val)
+  end
 end


### PR DESCRIPTION
Only set highlight when it doesn't already exist, allowing users to customize highlight groups without being overwritten.